### PR TITLE
wrap long lines

### DIFF
--- a/_episodes/01-motivation.md
+++ b/_episodes/01-motivation.md
@@ -12,15 +12,24 @@ keypoints:
 ---
 
 ## Why?
-We want to combine the strengths of scripting langugage, especially Python with the strengths of a compiled language. A high-level scripting language is more efficient for prototyping than a compiled language with its'  compile-debug development.
+We want to combine the strengths of scripting langugage, especially Python with
+the strengths of a compiled language. A high-level scripting language is more
+efficient for prototyping than a compiled language with its'  compile-debug
+development.
 
-We can have legacy code that we want to make use of, but the nature of the code base inhibits further development. Hence we want to move forward in high-level scripting language, but make use of previous code or work.
+We can have legacy code that we want to make use of, but the nature of the code
+base inhibits further development. Hence we want to move forward in high-level
+scripting language, but make use of previous code or work.
 
-Our scripting language code base has performance problems. The time consumed to solve certain task is to high. Consequently we want to move certain functions to a compiled language.
+Our scripting language code base has performance problems. The time consumed to
+solve certain task is to high. Consequently we want to move certain functions
+to a compiled language.
 
-All these motivation point to a situation where we want to extend the ability of our high-level scripting interpreter, our case Python.
+All these motivation point to a situation where we want to extend the ability
+of our high-level scripting interpreter, our case Python.
 
-We start out with examples with different technologies. We are getting our hands dirty with SWIG, Boost and Pybind11. 
+We start out with examples with different technologies. We are getting our
+hands dirty with SWIG, Boost and Pybind11. 
 
 ![Python and C/C++](../assets/img/python-c.png "Python and C/C++. Licences CC BY 3.0"){:class="img-repsonsive"}
 
@@ -33,9 +42,13 @@ We start out with examples with different technologies. We are getting our hands
 0.8660254036861398
 >>> 
 ```
-Here we import the well known scipy, https://www.scipy.org package, and call the function sin(). We also import the unknown tss_ext library and call a function ts_sin() which returns the approximately same result as scipy.sin().
+Here we import the well known scipy, https://www.scipy.org package, and call
+the function sin(). We also import the unknown tss_ext library and call a
+function ts_sin() which returns the approximately same result as scipy.sin().
 
-The tss_ext library is a shared library built from C++ source files, made available to the python interpreter with the Boost Library. Here the python scripting environment has been extended with functions from a C++ code base.
+The tss_ext library is a shared library built from C++ source files, made
+available to the python interpreter with the Boost Library. Here the python
+scripting environment has been extended with functions from a C++ code base.
 
 
 ## How does a scripting language to talk to C/C++?
@@ -68,9 +81,12 @@ class Employee {
 ```
 ![C/C++-class hierarchy](../assets/img/classhierarchy.png "Class hierarchy. Licences CC BY 3.0"){:class="img-repsonsive"}
 
-The figure shows two classes SalariedEmployee and CommisionEmploye which inherit Employee. These two classes must implement the virtual functions according to the C++-standard.
+The figure shows two classes SalariedEmployee and CommisionEmploye which
+inherit Employee. These two classes must implement the virtual functions
+according to the C++-standard.
 
-From Python we would like to make use of these classes and their methods in a way like this:
+From Python we would like to make use of these classes and their methods in a
+way like this:
 
 ```Python
 >>> t = CommisionEmployee('Molly','Malone', "333-33-3333",19000,.05,)
@@ -80,9 +96,16 @@ From Python we would like to make use of these classes and their methods in a wa
 >>> u.earnings()
 15000
 ```
-How do we accomplish this, making the Employee class hierarchy available in the python interpreter? Python, as most scripting language, has a foreign function interface which defines how external functions commands can hook into the interpreter, here the C/C++ reference manual https://docs.python.org/2/c-api/.
+How do we accomplish this, making the Employee class hierarchy available in the
+python interpreter? Python, as most scripting language, has a foreign function
+interface which defines how external functions commands can hook into the
+interpreter, here the C/C++ reference manual https://docs.python.org/2/c-api/.
 
-You will need to write a special wrapper that serves as a glue between the C/C++function and the Python interpreter. The Python interpreter also needs to known how to call the wrapper (the name,arguments. We could do this by following the reference manual, but here we will show how this can be done with different tools.
+You will need to write a special wrapper that serves as a glue between the
+C/C++function and the Python interpreter. The Python interpreter also needs to
+known how to call the wrapper (the name,arguments. We could do this by
+following the reference manual, but here we will show how this can be done with
+different tools.
 
 
 Inspired by the SWIG-3.0 documentation, http://www.swig.org/Doc3.0/

--- a/_episodes/02-overview.md
+++ b/_episodes/02-overview.md
@@ -20,19 +20,41 @@ There exist several technologies which make this possible:
 * Pybind11
 * Cython
 
-Simplified Wrapper and Interface Generator (SWIG) is a tool that simplies the two step process of making a wrapper and generating a interface which makes the wrapper callable from the interpreter. According to the SWIG documentation, "SWIG was orignally designed to make it extremely easy for scientist and engineers to build extensible scientific software without having a degree in software engineering". So SWIG should really be the only thing we need, right? Could be, but before giving a motivation for the other tools, it is worth mentioning that SWIG support a range of interpreting languages, not only Python.
+Simplified Wrapper and Interface Generator (SWIG) is a tool that simplies the
+two step process of making a wrapper and generating a interface which makes the
+wrapper callable from the interpreter. According to the SWIG documentation,
+"SWIG was orignally designed to make it extremely easy for scientist and
+engineers to build extensible scientific software without having a degree in
+software engineering". So SWIG should really be the only thing we need, right?
+Could be, but before giving a motivation for the other tools, it is worth
+mentioning that SWIG support a range of interpreting languages, not only
+Python.
 
-F2PY is a tool for interfacing Fortan and Python. According to "Python Scripting for Computational Science" transfering Numpy arrays between Python and compiled Fortran code is easier with F2PY than SWIG.
+F2PY is a tool for interfacing Fortan and Python. According to "Python
+Scripting for Computational Science" transfering Numpy arrays between Python
+and compiled Fortran code is easier with F2PY than SWIG.
 
-Boost is a huge C++-library which works with almost any C++-compiler. The Python interface tool was added to the Boost library around 2002 by David Abrahams. Hence, if you a have special C++-compiler, Boost.Python could be your most suitable tool for integrating Python and C++.
+Boost is a huge C++-library which works with almost any C++-compiler. The
+Python interface tool was added to the Boost library around 2002 by David
+Abrahams. Hence, if you a have special C++-compiler, Boost.Python could be your
+most suitable tool for integrating Python and C++.
 
-"Pybind11 is a lightweight-header only library that exposes C++-types in Python and vice versa, mainly to create Python bindings of existing C++ code.", according to the Pybind11 web page, https://pybind11.readthedocs.io/en/stable/intro.html. The point it is lightweight and targeting the combination of Python and C++11compliant compilers. Consequently, the interface code becomes more straight forward.
+"Pybind11 is a lightweight-header only library that exposes C++-types in Python
+and vice versa, mainly to create Python bindings of existing C++ code.",
+according to the Pybind11 web page,
+https://pybind11.readthedocs.io/en/stable/intro.html. The point it is
+lightweight and targeting the combination of Python and C++11compliant
+compilers. Consequently, the interface code becomes more straight forward.
 
-Cython:"All of this makes Cython the ideal language for wrapping external C libraries, embedding CPython into existing applications, and for fast C modules that speed up the execution of Python code.", see webpage http://cython.org
+Cython:"All of this makes Cython the ideal language for wrapping external C
+libraries, embedding CPython into existing applications, and for fast C modules
+that speed up the execution of Python code.", see webpage http://cython.org
 
 
 ##SWIG
-Our source code contains three functions, Taylor series of sin(), cos() and a helper function factorial(). We will make these functions available in our Python interpreter with the use of SWIG
+Our source code contains three functions, Taylor series of sin(), cos() and a
+helper function factorial(). We will make these functions available in our
+Python interpreter with the use of SWIG
 
 ``` Simplified Wrapper and Interface Generator,http://www.swig.org/ (SWIG). It is a software tool for making programs/applications written C/C++ accessible from a high-level programming language. Python is on of these high-level programming languages, but there is a range of others(C#,Common Lisp, Go,R, Lua et cetera).
 ```
@@ -50,7 +72,8 @@ This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 ```
-Create a SWIG enabled environment in conda. Here we also add scipy to have available for possible comparisons with the methods we have implemented.
+Create a SWIG enabled environment in conda. Here we also add scipy to have
+available for possible comparisons with the methods we have implemented.
 
 
 ``` shell
@@ -179,7 +202,9 @@ double cos(double x,int N) {
 }
 
 ```
-Now we need a interface file which describes how these functions can be called. In SWIG nomenclature this is a i-file. Here we define the module name and which functions that needs wrappers.
+Now we need a interface file which describes how these functions can be called.
+In SWIG nomenclature this is a i-file. Here we define the module name and which
+functions that needs wrappers.
 
 ```C++
 // taylor.i
@@ -553,7 +578,9 @@ pybind11-2.1.1 100% |##########################################| Time: 0:00:00 2
 source deactivate
 ```
 ## Managing environments under Anaconda
-You will now have at least four Anaconda environements: the original and three create as part of this exercise. You can list environemnts, and activate or deactive  the environments with the following commands:
+You will now have at least four Anaconda environements: the original and three
+create as part of this exercise. You can list environemnts, and activate or
+deactive  the environments with the following commands:
 ```shell
 conda info --envs
 source activate <environment name>


### PR DESCRIPTION
This is important so that we get less conflicts when changing wording or fixing typos. It creates more silent diffs.